### PR TITLE
Handle unavailable packages

### DIFF
--- a/src/display/index.js
+++ b/src/display/index.js
@@ -17,7 +17,7 @@ const TYPE_TO_MODE = {
 const logLine = entry => {
   if (typeof entry.latest === 'undefined') {
     console.log(
-      `* Couldn‘t find versions for ${chalk.red(entry.name)}. Please check manually`
+      `* Couldn‘t find version for ${chalk.red(entry.name)} (check manually)`
     )
   } else {
     console.log(

--- a/src/display/index.js
+++ b/src/display/index.js
@@ -15,11 +15,17 @@ const TYPE_TO_MODE = {
  * @param {String} entry.latest - Latest version of dependency
  */
 const logLine = entry => {
-  console.log(
-    `* ${chalk.cyan(entry.name)}${chalk.dim(' @ ')}${chalk.blue(
-      entry.latest
-    )} is available (currently ${chalk.yellow(entry.range)})`
-  )
+  if (typeof entry.latest === 'undefined') {
+    console.log(
+      `* Couldn‘t find versions for ${chalk.red(entry.name)}. Please check manually`
+    )
+  } else {
+    console.log(
+      `* ${chalk.cyan(entry.name)}${chalk.dim(' @ ')}${chalk.blue(
+        entry.latest
+      )} is available (currently ${chalk.yellow(entry.range)})`
+    )
+  }
 }
 
 /**
@@ -32,7 +38,7 @@ const logCommand = (entries, type) => {
     return
   }
 
-  const command = entries.reduce((cmd, entry) => {
+  const command = entries.filter(entry => Boolean(entry.latest)).reduce((cmd, entry) => {
     return cmd + ' ' + entry.name + '@' + entry.latest
   }, `npm install ${TYPE_TO_MODE[type]}`)
 


### PR DESCRIPTION
In some cases, for example when packages are deprecated, the available package versions will be empty, causing the program to display `undefined` as the latest version. This is a quick fix, maybe there is more to be done for this case, not sure.